### PR TITLE
get_sha_range(): handle PR target moving

### DIFF
--- a/downstream_cherry_picker/__init__.py
+++ b/downstream_cherry_picker/__init__.py
@@ -82,7 +82,13 @@ def get_sha_range(owner, repo, number):
                 # Not sure this can ever happen, but let's bail if it does:
                 msg = 'Commits %s and %s are both children of base commit %s'
                 raise RuntimeError(msg % (first, commit['sha'], base))
-
+    if first is None:
+        # We could not find any commit in this PR that is a direct parent of
+        # the base commit (ie the current target branch).
+        # This can happen when a PR is initially targeted to one branch
+        # (eg # "jewel-next"), and then someone changes it to target a another
+        # branch (eg "jewel").
+        first = base
     return (first, head)
 
 


### PR DESCRIPTION
Prior to this change, if a PR was originally targeted at one branch and then moved to a second branch, downstream-cherry-picker would fail to determine the first commit sha1 to cherry-pick.

GitHub's main Pull Request API endpoint populates the "base" value as the new destination branch's sha1. and it's possible (likely?) that when a PR is re-targeted like this, none of the commits in the PR will have the new base sha1 as a parent.

When this happened, downstream-cherry-picker would return "None" for "first" in `get_sha_range()`, which causes the "git cherry-pick" argument to look like "None~..1926adc826de9ddaaa04138ce2a0b276eeda7ad1", which of course fails.

In these cases, fall back to just choosing the "first" commit in the PR as the first one to cherry-pick.